### PR TITLE
LLVM JIT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "cc"
+version = "1.0.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef611cc68ff783f18535d77ddd080185275713d852c4f5cbb6122c462a7a825c"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,6 +75,21 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "cloudabi"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "env_logger"
@@ -138,6 +159,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "inkwell"
+version = "0.1.0"
+source = "git+https://github.com/TheDan64/inkwell#7b2e20f91df6cf7a13f6e0909c85d893d1c2abb9"
+dependencies = [
+ "either",
+ "inkwell_internals",
+ "libc",
+ "llvm-sys",
+ "once_cell",
+ "parking_lot",
+ "regex",
+]
+
+[[package]]
+name = "inkwell_internals"
+version = "0.2.0"
+source = "git+https://github.com/TheDan64/inkwell#7b2e20f91df6cf7a13f6e0909c85d893d1c2abb9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63312a18f7ea8760cdd0a7c5aac1a619752a246b833545e3e36d1f81f7cd9e66"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +202,28 @@ name = "libc"
 version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
+
+[[package]]
+name = "llvm-sys"
+version = "100.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9109e19fbfac3458f2970189719fa19f1007c6fd4e08c44fdebf4be0ddbe261d"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "regex",
+ "semver",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28247cc5a5be2f05fbcd76dd0cf2c7d3b5400cb978a28042abcd4fa0b3f8261c"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -165,10 +241,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
+name = "once_cell"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
+
+[[package]]
 name = "os_str_bytes"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ac6fe3538f701e339953a3ebbe4f39941aababa8a3f6964635b24ab526daeac"
+
+[[package]]
+name = "parking_lot"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
+dependencies = [
+ "cfg-if",
+ "cloudabi",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -266,6 +374,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+
+[[package]]
 name = "regex"
 version = "1.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,11 +398,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "smallvec"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
+
+[[package]]
 name = "strategic-communication"
 version = "1.1.0"
 dependencies = [
  "clap",
  "env_logger",
+ "inkwell",
  "lazy_static",
  "log",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ lazy_static = "1.4.0"
 log = "0.4.0"
 env_logger = "0.7.1"
 rand = "0.7.3"
+inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "master", features = ["llvm10-0"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,9 @@ version = "1.1.0"
 authors = ["Steven Goldberg"]
 edition = "2018"
 
+[features]
+llvm = ["inkwell"]
+
 [dependencies]
 clap = "3.0.0-beta.2"
 regex = "1.3.9"
@@ -11,4 +14,4 @@ lazy_static = "1.4.0"
 log = "0.4.0"
 env_logger = "0.7.1"
 rand = "0.7.3"
-inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "master", features = ["llvm10-0"] }
+inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "master", features = ["llvm10-0"], optional = true }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -81,10 +81,18 @@ pub fn run(program: &Program, print_ir: bool, view_cfg: bool, optimization_level
     Ok(())
 }
 
+fn unique_label<'a,V>(labels: &HashMap<String,V>, name: &'a str) -> String {
+    let mut label = name.to_string();
+    while labels.contains_key(&label) {
+        label = format!("_{}", label);
+    }
+    return label;
+}
+
 impl<'ctx> CodeGen<'ctx> {
     fn create_basic_blocks(&mut self, function: FunctionValue<'ctx>, labels: &HashMap<String, usize>) {
         // basic block for entry point
-        let basic_block = self.context.append_basic_block(function, "entry");
+        let basic_block = self.context.append_basic_block(function, &unique_label(labels, "entry"));
         self.builder.position_at_end(basic_block);
 
         // basic blocks for labels, in line order

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -76,7 +76,6 @@ impl<'ctx> CodeGen<'ctx> {
         lines_with_labels.sort();
         for line in lines_with_labels.iter() {
             let label = &labels_by_line[line];
-            println!("line {}: {}", line, label);
             let block = self.context.append_basic_block(function, &label);
             self.labels.insert(label.to_string(), block);
         }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -194,13 +194,15 @@ impl<'ctx> CodeGen<'ctx> {
     }
 
     pub fn gen_label(&self, name: &str) {
+        let current_block = self.builder.get_insert_block().unwrap();
         let basic_block = self.labels[name];
-        self.builder.build_unconditional_branch(basic_block);
+        if current_block.get_terminator() == None {
+            self.builder.build_unconditional_branch(basic_block);
+        }
         self.builder.position_at_end(basic_block);
     }
 
     pub fn gen_jump(&self, label: &str) {
-        println!("finding label {}", label);
         let branch_block = self.labels[label];
         self.builder.build_unconditional_branch(branch_block);
     }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -27,7 +27,7 @@ pub struct CodeGen<'ctx> {
 
 type EntryPoint = unsafe extern "C" fn();
 
-pub fn run(program: &Program, print_ir: bool, optimization_level: OptimizationLevel) -> Result<(), Box<dyn Error>> {
+pub fn run(program: &Program, print_ir: bool, view_cfg: bool, optimization_level: OptimizationLevel) -> Result<(), Box<dyn Error>> {
     let context = Context::create();
     let module = context.create_module(&program.name);
     let execution_engine = module.create_jit_execution_engine(optimization_level)?;    
@@ -58,14 +58,15 @@ pub fn run(program: &Program, print_ir: bool, optimization_level: OptimizationLe
     // compile
     codegen.compile(&program)?;
 
-    // optimize
     if let Some(function) = codegen.module.get_function("main") {
-        println!("Running optimizer");
+        // optimize
         fpm.run_on(&function);
+        // view cfg
+        if view_cfg {
+            function.view_function_cfg_only();
+        }
     }
     
-    
-
     // print module
     if print_ir {
         codegen.module.print_to_stderr();

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1,0 +1,232 @@
+use crate::{
+    Program, OPERATIONS, REGISTER_NAMES, operations
+};
+use inkwell::OptimizationLevel;
+use inkwell::IntPredicate;
+use inkwell::basic_block::BasicBlock;
+use inkwell::builder::Builder;
+use inkwell::context::Context;
+use inkwell::execution_engine::{ExecutionEngine, JitFunction};
+use inkwell::module::{Linkage, Module};
+//use inkwell::targets::{InitializationConfig, Target};
+use inkwell::types::{IntType};
+use inkwell::values::{IntValue, PointerValue, FunctionValue};
+use operations::{Operand, Transformation};
+use std::collections::HashMap;
+use std::error::Error;
+
+pub struct CodeGen<'ctx> {
+    context: &'ctx Context,
+    module: Module<'ctx>,
+    builder: Builder<'ctx>,
+    execution_engine: ExecutionEngine<'ctx>,
+    register_type: IntType<'ctx>,
+    registers: HashMap<String, PointerValue<'ctx>>,
+    labels: HashMap<String, BasicBlock<'ctx>>,
+}
+
+type EntryPoint = unsafe extern "C" fn();
+
+pub fn run(program: &Program) -> Result<(), Box<dyn Error>> {
+    let context = Context::create();
+    let module = context.create_module("business");
+    let execution_engine = module.create_jit_execution_engine(OptimizationLevel::None)?;    
+    let builder = context.create_builder();
+    let register_type = context.i32_type();
+
+    // add builtins
+    module.add_function("print_value", context.i32_type().fn_type(&[context.i32_type().into()], false), Some(Linkage::External));
+    module.add_function("getchar", context.i32_type().fn_type(&[], false), Some(Linkage::External));
+
+    let mut codegen = CodeGen {
+        context: &context,
+        module: module,
+        builder: builder,
+        execution_engine: execution_engine,
+        register_type: register_type,
+        registers: HashMap::new(),
+        labels: HashMap::new()
+    };
+
+    // compile
+    codegen.compile(&program)?;
+    
+    // print module
+    codegen.module.print_to_stderr();
+
+    // run program
+    unsafe {
+        let function: JitFunction<EntryPoint> = codegen.execution_engine.get_function("main")?;
+        function.call();
+    }
+
+    Ok(())
+}
+
+impl<'ctx> CodeGen<'ctx> {
+    fn create_basic_blocks(&mut self, function: FunctionValue<'ctx>, labels: &HashMap<String, usize>) {
+        // basic block for entry point
+        let basic_block = self.context.append_basic_block(function, "entry");
+        self.builder.position_at_end(basic_block);
+
+        // basic blocks for labels, in line order
+        let labels_by_line: HashMap<usize, String> = labels.iter().map(|(label, line)| (*line, label.to_string())).collect();
+        let mut lines_with_labels: Vec<_> = labels.values().map(|x|x).collect();
+        lines_with_labels.sort();
+        for line in lines_with_labels.iter() {
+            let label = &labels_by_line[line];
+            println!("line {}: {}", line, label);
+            let block = self.context.append_basic_block(function, &label);
+            self.labels.insert(label.to_string(), block);
+        }
+    }
+
+    fn compile(&mut self, program: &Program) -> Result<(), Box<dyn Error>> {
+        // create function
+        let fn_type = self.context.void_type().fn_type(&[], false);
+        let function = self.module.add_function("main", fn_type, None);
+
+        // create basic blocks
+        self.create_basic_blocks(function, &program.labels);
+
+        // allocate registers
+        self.registers = REGISTER_NAMES
+            .iter()
+            .map(|name| (name.to_string(), self.builder.build_alloca(self.register_type, name)))
+            .collect();
+
+        // compile code
+        for i in 0..program.source.len() {        
+            let line = &program.source[i];
+            for op in OPERATIONS.iter() {
+                if op.pattern.is_match(line) {
+                    let operands = op.pattern.replace(&line, "").to_string();
+                    (op.func)(&operands, i, &self)?;
+                }
+            }
+        }
+    
+        // end function
+        self.builder.build_return(None);
+
+        Ok(())
+    }
+
+    pub fn has_register(&self, name: &str) -> bool {
+        return self.registers.contains_key(name);
+    }
+
+    pub fn has_label(&self, label: &str) -> bool {
+        return self.labels.contains_key(label);
+    }
+
+    fn const_int(&self, value: i32) -> IntValue<'ctx> {
+        return self.register_type.const_int(value as u32 as u64, true);
+    }
+
+    fn op_reg_imm(&self, register: PointerValue<'ctx>, operand: i32, build_func: fn(&Builder<'ctx>, IntValue<'ctx>, IntValue<'ctx>, &str) -> IntValue<'ctx>) {
+        let value = self.builder.build_load(register, "value").into_int_value();
+        let value = (build_func)(&self.builder, value, self.const_int(operand), "value");
+        self.builder.build_store(register, value);
+    }
+
+    fn op_reg_reg(&self, register: PointerValue<'ctx>, operand: &str, build_func: fn(&Builder<'ctx>, IntValue<'ctx>, IntValue<'ctx>, &str) -> IntValue<'ctx>) {
+        let operand_reg = self.registers.get(&operand.to_string()).unwrap();
+        let value = self.builder.build_load(register, "value").into_int_value();
+        let operand_value = self.builder.build_load(*operand_reg, "operand").into_int_value();
+        let value = (build_func)(&self.builder, value, operand_value, "value");
+        self.builder.build_store(register, value);
+    }
+    
+    pub fn gen_modify_register(&self, name: &str, transformation: operations::Transformation) {
+        let register = self.registers.get(&name.to_string()).unwrap();
+
+        match transformation {
+            Transformation::Add(Operand::Literal(literal)) => {
+                self.op_reg_imm(*register, *literal, Builder::build_int_add);
+            }
+            Transformation::Add(Operand::Register(operand_reg)) => {
+                self.op_reg_reg(*register, operand_reg, Builder::build_int_add);
+            }
+            Transformation::Subtract(Operand::Literal(literal)) => {
+                self.op_reg_imm(*register, *literal, Builder::build_int_sub);
+            }
+            Transformation::Subtract(Operand::Register(operand_reg)) => {
+                self.op_reg_reg(*register, operand_reg, Builder::build_int_sub);
+            }
+            Transformation::Multiply(Operand::Literal(literal)) => {
+                self.op_reg_imm(*register, *literal, Builder::build_int_mul);
+            }
+            Transformation::Multiply(Operand::Register(operand_reg)) => {
+                self.op_reg_reg(*register, operand_reg, Builder::build_int_mul);
+            }
+            Transformation::Divide(Operand::Literal(literal)) => {
+                self.op_reg_imm(*register, *literal, Builder::build_int_signed_div);
+            }
+            Transformation::Divide(Operand::Register(operand_reg)) => {
+                self.op_reg_reg(*register, operand_reg, Builder::build_int_signed_div);
+            }
+            Transformation::Set(Operand::Literal(literal)) => {
+                self.builder.build_store(*register, self.const_int(*literal));
+            }
+            Transformation::Set(Operand::Register(src)) => {
+                let src_register = self.registers.get(&src.to_string()).unwrap();
+                let value = self.builder.build_load(*src_register, "value");
+                self.builder.build_store(*register, value);
+            }
+            _ => { panic!("Unhandled transformation!") }
+        };
+    }
+
+    pub fn gen_print(&self, register: &str) {
+        let register = self.registers.get(&register.to_string()).unwrap();
+        let value = self.builder.build_load(*register, "value");
+        self.builder.build_call(self.module.get_function("print_value").unwrap(), &[value], "print");
+    }
+
+    pub fn gen_read(&self, register: &str) {
+        let register = self.registers.get(&register.to_string()).unwrap();
+        let result = self.builder.build_call(self.module.get_function("getchar").unwrap(), &[], "read")
+            .try_as_basic_value()
+            .left()
+            .unwrap();
+        self.builder.build_store(*register, result);
+    }
+
+    pub fn gen_label(&self, name: &str) {
+        let basic_block = self.labels[name];
+        self.builder.build_unconditional_branch(basic_block);
+        self.builder.position_at_end(basic_block);
+    }
+
+    pub fn gen_jump(&self, label: &str) {
+        println!("finding label {}", label);
+        let branch_block = self.labels[label];
+        self.builder.build_unconditional_branch(branch_block);
+    }
+
+    fn gen_cond_zero_jump(&self, register: &str, cond: IntPredicate, label: &str) {
+        // create a new basic block at the current insertion point
+        // to be used as an "else block"
+        let current_block = self.builder.get_insert_block().unwrap();
+        let else_block_label = format!("{}'", current_block.get_name().to_str().unwrap());
+        let else_block = self.context.insert_basic_block_after(current_block, &else_block_label);
+        let then_block = self.labels[label];
+
+        // comparison
+        let register = self.registers.get(&register.to_string()).unwrap();
+        let value = self.builder.build_load(*register, "value").into_int_value();
+        let cond = self.builder.build_int_compare(cond, value, self.register_type.const_zero(), "cmp");
+        
+        self.builder.build_conditional_branch(cond, then_block, else_block);
+        self.builder.position_at_end(else_block);
+    }
+
+    pub fn gen_jump_if_zero(&self, register: &str, label: &str) {
+        self.gen_cond_zero_jump(register, IntPredicate::EQ, label);
+    }
+
+    pub fn gen_jump_if_neg(&self, register: &str, label: &str) {
+        self.gen_cond_zero_jump(register, IntPredicate::SLT, label);
+    }
+}

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -37,6 +37,7 @@ pub fn run(program: &Program) -> Result<(), Box<dyn Error>> {
     // add builtins
     module.add_function("print_value", context.i32_type().fn_type(&[context.i32_type().into()], false), Some(Linkage::External));
     module.add_function("getchar", context.i32_type().fn_type(&[], false), Some(Linkage::External));
+    module.add_function("randomize", context.i32_type().fn_type(&[], false), Some(Linkage::External));
 
     let mut codegen = CodeGen {
         context: &context,
@@ -230,5 +231,14 @@ impl<'ctx> CodeGen<'ctx> {
 
     pub fn gen_jump_if_neg(&self, register: &str, label: &str) {
         self.gen_cond_zero_jump(register, IntPredicate::SLT, label);
+    }
+
+    pub fn gen_randomize(&self, register: &str) {
+        let register = self.registers.get(&register.to_string()).unwrap();
+        let result = self.builder.build_call(self.module.get_function("randomize").unwrap(), &[], "randomize")
+            .try_as_basic_value()
+            .left()
+            .unwrap();
+        self.builder.build_store(*register, result);
     }
 }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -29,7 +29,7 @@ type EntryPoint = unsafe extern "C" fn();
 
 pub fn run(program: &Program, print_ir: bool, optimization_level: OptimizationLevel) -> Result<(), Box<dyn Error>> {
     let context = Context::create();
-    let module = context.create_module("business");
+    let module = context.create_module(&program.name);
     let execution_engine = module.create_jit_execution_engine(optimization_level)?;    
     let builder = context.create_builder();
     let register_type = context.i32_type();

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -27,7 +27,7 @@ pub struct CodeGen<'ctx> {
 
 type EntryPoint = unsafe extern "C" fn();
 
-pub fn run(program: &Program) -> Result<(), Box<dyn Error>> {
+pub fn run(program: &Program, print_ir: bool) -> Result<(), Box<dyn Error>> {
     let context = Context::create();
     let module = context.create_module("business");
     let execution_engine = module.create_jit_execution_engine(OptimizationLevel::None)?;    
@@ -53,7 +53,9 @@ pub fn run(program: &Program) -> Result<(), Box<dyn Error>> {
     codegen.compile(&program)?;
     
     // print module
-    codegen.module.print_to_stderr();
+    if print_ir {
+        codegen.module.print_to_stderr();
+    }
 
     // run program
     unsafe {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1,0 +1,162 @@
+use crate::{
+    Error, OPERATIONS, operations, Opts, Program, REGISTER_NAMES, lib
+};
+
+use operations::{Operand, Transformation};
+use std::collections::HashMap;
+use std::io::Read;
+
+/// A representation of the state of "memory" during the execution of a program.
+#[derive(Debug)]
+pub struct Context<'ctx> {
+    /// Program being executed.
+    program: &'ctx Program,
+    /// Map of register names to their current values.
+    registers: HashMap<String, i32>,
+    /// The 0-indexed line number currently being executed.
+    current_line_number: usize,
+}
+
+impl Context<'_> {
+    pub fn run(program: &Program, _opts: &Opts) -> Result<(), Box<dyn std::error::Error>> {
+        let mut context = Context {
+            program: &program,
+            registers: REGISTER_NAMES
+                .iter()
+                .map(|name| (name.to_string(), 0))
+                .collect(),
+            current_line_number: 0,
+        };
+
+        debug!("created context: {:?}", context);
+        while context.current_line_number < context.program.source.len() {
+            context.execute_current_line()?;
+        }
+
+        Ok(())
+    }
+
+    /// Executes the line at `source[current_line_number]` and sets `current_line_number` to the index of the next line to execute.
+    fn execute_current_line(&mut self) -> Result<(), Error> {
+        if self.current_line_number >= self.program.source.len() {
+            return Err(Error::new("invalid line number", self.current_line_number));
+        }
+
+        let line = &self.program.source[self.current_line_number];
+        debug!("executing line {}: {}", self.current_line_number, line);
+
+        for op in OPERATIONS.iter() {
+            if op.pattern.is_match(line) {
+                let operands = op.pattern.replace(&line, "").to_string();
+                trace!("registers before: {:?}", self.registers);
+                (op.func)(&operands, self.current_line_number, self)?;
+                trace!("registers after: {:?}", self.registers);
+                self.current_line_number += 1;
+                return Ok(());
+            }
+        }
+
+        Err(Error::new("unexpected expression", self.current_line_number))
+    }
+    
+    pub fn has_register(&self, name: &str) -> bool {
+        return self.registers.contains_key(name);
+    }
+
+    pub fn has_label(&self, label: &str) -> bool {
+        return self.program.labels.contains_key(label);
+    }
+
+    pub fn get_register_value(&self, name: &str) -> i32 {
+        self.registers[name]
+    }
+
+    pub fn set_register_value(&mut self, name: &str, value: i32) {
+        self.registers.insert(name.to_string(), value);
+    }
+
+    pub fn gen_modify_register(&mut self, name: &str, transformation: operations::Transformation) {
+        let value = self.get_register_value(name);
+
+        match transformation {
+            Transformation::Add(Operand::Literal(literal)) => {
+                self.set_register_value(name, value + (*literal));
+            }
+            Transformation::Add(Operand::Register(operand_reg)) => {
+                let value2 = self.get_register_value(operand_reg);
+                self.set_register_value(name, value + value2);
+            }
+            Transformation::Subtract(Operand::Literal(literal)) => {
+                self.set_register_value(name, value - (*literal));
+            }
+            Transformation::Subtract(Operand::Register(operand_reg)) => {
+                let value2 = self.get_register_value(operand_reg);
+                self.set_register_value(name, value - value2);
+            }
+            Transformation::Multiply(Operand::Literal(literal)) => {
+                self.set_register_value(name, value * (*literal));
+            }
+            Transformation::Multiply(Operand::Register(operand_reg)) => {
+                let value2 = self.get_register_value(operand_reg);
+                self.set_register_value(name, value * value2);
+            }
+            Transformation::Divide(Operand::Literal(literal)) => {
+                self.set_register_value(name, value / (*literal));
+            }
+            Transformation::Divide(Operand::Register(operand_reg)) => {
+                let value2 = self.get_register_value(operand_reg);
+                self.set_register_value(name, value / value2);
+            }
+            Transformation::Set(Operand::Literal(literal)) => {
+                self.set_register_value(name, *literal);
+            }
+            Transformation::Set(Operand::Register(src)) => {
+                self.set_register_value(name, self.get_register_value(src));
+            }
+            _ => { panic!("Unhandled transformation!") }
+        };
+    }
+
+    pub fn gen_print(&mut self, register: &str) {
+        let value = self.get_register_value(register);
+        lib::print_value(value);
+    }
+
+    pub fn gen_read(&mut self, register: &str) {
+        let new_value = match std::io::stdin().bytes().next() {
+            Some(b) => match b {
+                Ok(b) => b as i32,
+                Err(_) => -1,
+            },
+            None => -1,
+        };
+        self.set_register_value(register, new_value);
+    }
+
+    pub fn gen_label(&mut self, _name: &str) {
+        // nothing to do here
+    }
+
+    pub fn gen_jump(&mut self, label: &str) {
+        let line_number = self.program.labels[label];
+        self.current_line_number = line_number;
+    }
+
+    pub fn gen_jump_if_zero(&mut self, register: &str, label: &str) {
+        let value = self.get_register_value(register);
+        if value == 0 {
+            self.gen_jump(label);
+        }
+    }
+
+    pub fn gen_jump_if_neg(&mut self, register: &str, label: &str) {
+        let value = self.get_register_value(register);
+        if value < 0 {
+            self.gen_jump(label);
+        }
+    }
+
+    pub fn gen_randomize(&mut self, register: &str) {
+        self.set_register_value(register, lib::randomize());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,31 @@
+use std::io::Write;
+
+/// Functions called by Strategic Communication programs
+
+#[no_mangle]
+pub extern fn print_value(to_print: i32) {
+    if to_print < 0 {
+        panic!(
+                "{} does not correspond to a valid UTF-8 character",
+                to_print
+            );
+    }
+
+    match std::char::from_u32(to_print as u32) {
+        Some(c) => {
+            print!("{}", c);
+            std::io::stdout().flush().unwrap();
+        }
+        _ => {
+            panic!(
+                "{} does not correspond to a valid UTF-8 character",
+                to_print
+            );
+        }
+    }
+}
+
+// Adding the functions above to static,
+// so Rust compiler won't remove them.
+#[used]
+static PRINT_VALUE_FUNC: extern "C" fn(i32) = print_value;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+use rand::Rng;
 use std::io::Write;
 
 /// Functions called by Strategic Communication programs
@@ -25,7 +26,16 @@ pub extern fn print_value(to_print: i32) {
     }
 }
 
+#[no_mangle]
+/// Returns a random number between 0 and 9 (inclusive).
+pub extern fn randomize() -> i32 {
+    rand::thread_rng().gen_range(0, 10)
+}
+
 // Adding the functions above to static,
 // so Rust compiler won't remove them.
 #[used]
 static PRINT_VALUE_FUNC: extern "C" fn(i32) = print_value;
+
+#[used]
+static RANDOMIZE_FUNC: extern "C" fn() -> i32 = randomize;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod lib;
 
 use clap::Clap;
 use codegen::CodeGen;
+use inkwell::OptimizationLevel;
 use regex::Regex;
 use std::collections::HashMap;
 use std::fmt;
@@ -122,8 +123,19 @@ pub struct Opts {
     /// Print the LLVM IR to the console
     #[clap(short('i'), long)]
     print_ir: bool,
+    #[clap(short('O'), long, possible_values(&["0","1","2","3"]), default_value("2"))]
+    optimization_level: u8,
     /// The path to the file containing source code to execute
     file: String,
+}
+
+fn parse_optimization_level(level: u8) -> OptimizationLevel {
+    match level {
+        1 => OptimizationLevel::Less,
+        2 => OptimizationLevel::Default,
+        3 => OptimizationLevel::Aggressive,
+        _ => OptimizationLevel::None,
+    }
 }
 
 fn main() {
@@ -144,7 +156,7 @@ fn main() {
             eprintln!("error: {}", e);
         }
         Ok(p) => {
-            if let Err(e) = codegen::run(&p, opts.print_ir) {
+            if let Err(e) = codegen::run(&p, opts.print_ir, parse_optimization_level(opts.optimization_level)) {
                 eprintln!("error: {}", e);
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -254,7 +254,7 @@ impl Program {
                 match labels.get(&label_name) {
                     Some(other_line_number) => {
                         return Err(Error::new(
-                            &format!("duplicate label “{}”, previously defined on line {}", label_name, other_line_number), 
+                            &format!("duplicate label “{}”, previously defined on line {}", label_name, other_line_number + 1), 
                             line_number));
                         }
                     None => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,6 +124,9 @@ pub struct Opts {
     /// Print the LLVM IR to the console
     #[clap(short('i'), long)]
     print_ir: bool,
+    /// View the control flow graph
+    #[clap(long)]
+    view_cfg: bool,
     #[clap(short('O'), long, possible_values(&["0","1","2","3"]), default_value("2"))]
     optimization_level: u8,
     /// The path to the file containing source code to execute
@@ -158,7 +161,7 @@ fn main() {
             eprintln!("error: {}", e);
         }
         Ok(p) => {
-            if let Err(e) = codegen::run(&p, opts.print_ir, parse_optimization_level(opts.optimization_level)) {
+            if let Err(e) = codegen::run(&p, opts.print_ir, opts.view_cfg, parse_optimization_level(opts.optimization_level)) {
                 eprintln!("error: {}", e);
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use regex::Regex;
 use std::collections::HashMap;
 use std::fmt;
 use std::fs;
+use std::path::Path;
 
 #[macro_use]
 extern crate log;
@@ -143,14 +144,15 @@ fn main() {
 
     let opts = Opts::parse();
 
-    let source = fs::read_to_string(opts.file).expect("cannot open file");
+    let path = Path::new(&opts.file);
+    let source = fs::read_to_string(path).expect("cannot open file");
     let source: Vec<String> = source
         .split('\n')
         .map(|line| line.trim().to_lowercase())
         .filter(|line| !line.is_empty())
         .collect();
 
-    let program = Program::new(source);
+    let program = Program::new(path.file_name().unwrap().to_str().unwrap().to_string(), source);
     match program {
         Err(e) => {
             eprintln!("error: {}", e);
@@ -213,6 +215,8 @@ struct Operation {
 /// A representation of a program.
 #[derive(Debug)]
 pub struct Program {
+    /// The name of the program
+    name: String,
     /// The source code of the program, split by line.
     source: Vec<String>,
     /// Map of label names to the lines they are defined on.
@@ -224,9 +228,10 @@ impl Program {
     ///
     /// # Arguments
     /// * `source`: The source code of the program, split by line.
-    fn new(source: Vec<String>) -> Result<Program, Error> {
+    fn new(name: String, source: Vec<String>) -> Result<Program, Error> {
         let labels = Program::find_labels(&source)?;
         Ok(Program {
+            name,
             source,
             labels,
         })

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,7 +181,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "error on line {}: {}",
+            "line {}: {}",
             self.line_number + 1,
             self.message
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,7 +118,10 @@ lazy_static! {
 /// More information can be found at https://github.com/rotoclone/strategic-communication/blob/master/README.md
 #[derive(Clap)]
 #[clap(version = env!("CARGO_PKG_VERSION"))]
-struct Opts {
+pub struct Opts {
+    /// Print the LLVM IR to the console
+    #[clap(short('i'), long)]
+    print_ir: bool,
     /// The path to the file containing source code to execute
     file: String,
 }
@@ -141,7 +144,7 @@ fn main() {
             eprintln!("error: {}", e);
         }
         Ok(p) => {
-            if let Err(e) = codegen::run(&p) {
+            if let Err(e) = codegen::run(&p, opts.print_ir) {
                 eprintln!("error: {}", e);
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@ mod operations;
 use clap::Clap;
 use regex::Regex;
 use std::collections::HashMap;
-use std::error::Error;
 use std::fmt;
 use std::fs;
 
@@ -143,8 +142,8 @@ fn main() {
 /// # Arguments
 /// * `source`: The source code of the program to run, split by line.
 ///
-/// Returns `Err(RuntimeError)` if any errors occurred during the execution of the program.
-fn run(source: Vec<String>) -> Result<(), RuntimeError> {
+/// Returns `Err(Error)` if any errors occurred during the execution of the program.
+fn run(source: Vec<String>) -> Result<(), Error> {
     let mut context = Context::new(source);
     debug!("created context: {:?}", context);
     while context.current_line_number < context.source.len() {
@@ -155,16 +154,14 @@ fn run(source: Vec<String>) -> Result<(), RuntimeError> {
 
 /// An error during the execution of a program.
 #[derive(Debug)]
-pub struct RuntimeError {
+pub struct Error {
     /// The 0-indexed line number the error occurred on.
     line_number: usize,
     /// A message describing the error.
     message: String,
 }
 
-impl Error for RuntimeError {}
-
-impl fmt::Display for RuntimeError {
+impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
@@ -175,10 +172,10 @@ impl fmt::Display for RuntimeError {
     }
 }
 
-impl RuntimeError {
-    /// Creates a new `RuntimeError` with the provided message.
-    fn new(message: &str, context: &Context) -> RuntimeError {
-        RuntimeError {
+impl Error {
+    /// Creates a new `Error` with the provided message.
+    fn new(message: &str, context: &Context) -> Error {
+        Error {
             line_number: context.current_line_number,
             message: message.to_string(),
         }
@@ -186,7 +183,7 @@ impl RuntimeError {
 }
 
 /// Return type for operation execution functions.
-type OpResult = Result<(), RuntimeError>;
+type OpResult = Result<(), Error>;
 
 /// An operation corresponding to a line of source code.
 struct Operation {
@@ -245,9 +242,9 @@ impl Context {
     }
 
     /// Executes the line at `source[current_line_number]` and sets `current_line_number` to the index of the next line to execute.
-    fn execute_current_line(&mut self) -> Result<(), RuntimeError> {
+    fn execute_current_line(&mut self) -> Result<(), Error> {
         if self.current_line_number >= self.source.len() {
-            return Err(RuntimeError::new("invalid line number", self));
+            return Err(Error::new("invalid line number", self));
         }
 
         let line = &self.source[self.current_line_number];
@@ -264,6 +261,6 @@ impl Context {
             }
         }
 
-        Err(RuntimeError::new("unexpected expression", self))
+        Err(Error::new("unexpected expression", self))
     }
 }

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -1,78 +1,78 @@
 use crate::{
     OpResult, Error, LITERALS, LITERAL_CONNECTORS, OPERAND_CONNECTORS,
-    REGISTER_NAMES, codegen::CodeGen,
+    REGISTER_NAMES, Context
 };
 use regex::Regex;
 
 /// Adds a label.
-pub fn label(operands: &str, _line_number: usize, codegen: &CodeGen) -> OpResult {
+pub fn label(operands: &str, _line_number: usize, context: &mut Context) -> OpResult {
     debug!("label with operands: {}", operands);
-    codegen.gen_label(operands);
+    context.gen_label(operands);
     Ok(())
 }
 
 /// Increments a register's value by 1.
-pub fn increment(operands: &str, line_number: usize, codegen: &CodeGen) -> OpResult {
+pub fn increment(operands: &str, line_number: usize, context: &mut Context) -> OpResult {
     debug!("increment with operands: {}", operands);
 
     Ok(modify_register(
         operands,
         Transformation::Add(&Operand::Literal(1)),
         line_number,
-        &codegen,
+        context,
     )?)
 }
 
 /// Decrements a register's value by 1.
-pub fn decrement(operands: &str, line_number: usize, codegen: &CodeGen) -> OpResult {
+pub fn decrement(operands: &str, line_number: usize, context: &mut Context) -> OpResult {
     debug!("decrement with operands: {}", operands);
 
     Ok(modify_register(
         operands,
         Transformation::Add(&Operand::Literal(-1)),
         line_number,
-        &codegen,
+        context,
     )?)
 }
 
 /// Multiplies a register's value by -1.
-pub fn negate(operands: &str, line_number: usize, codegen: &CodeGen) -> OpResult {
+pub fn negate(operands: &str, line_number: usize, context: &mut Context) -> OpResult {
     debug!("negate with operands: {}", operands);
 
     Ok(modify_register(
         operands,
         Transformation::Multiply(&Operand::Literal(-1)),
         line_number,
-        &codegen,
+        context,
     )?)
 }
 
 /// Multiplies a register's value by 2.
-pub fn double(operands: &str, line_number: usize, codegen: &CodeGen) -> OpResult {
+pub fn double(operands: &str, line_number: usize, context: &mut Context) -> OpResult {
     debug!("double with operands: {}", operands);
 
     Ok(modify_register(
         operands,
         Transformation::Multiply(&Operand::Literal(2)),
         line_number,
-        &codegen,
+        context,
     )?)
 }
 
 /// Divides a register's value by 2.
-pub fn halve(operands: &str, line_number: usize, codegen: &CodeGen) -> OpResult {
+pub fn halve(operands: &str, line_number: usize, context: &mut Context) -> OpResult {
     debug!("halve with operands: {}", operands);
 
     Ok(modify_register(
         operands,
         Transformation::Divide(&Operand::Literal(2)),
         line_number,
-        &codegen,
+        context,
     )?)
 }
 
 /// Sets a register's value to a random number between 0 and 9 (inclusive).
-pub fn randomize(operands: &str, line_number: usize, codegen: &CodeGen) -> OpResult {
+pub fn randomize(operands: &str, line_number: usize, context: &mut Context) -> OpResult {
     debug!("randomize with operands: {}", operands);
 
     let operands = parse_operands(operands)?;
@@ -94,12 +94,12 @@ pub fn randomize(operands: &str, line_number: usize, codegen: &CodeGen) -> OpRes
         }
     };
 
-    codegen.gen_randomize(register);
+    context.gen_randomize(register);
     Ok(())
 }
 
 /// Sets a register's value to the value in another register or a literal value.
-pub fn assign(operands: &str, line_number: usize, codegen: &CodeGen) -> OpResult {
+pub fn assign(operands: &str, line_number: usize, context: &mut Context) -> OpResult {
     debug!("assignment with operands: {}", operands);
 
     let operands = parse_operands(operands)?;
@@ -126,7 +126,7 @@ pub fn assign(operands: &str, line_number: usize, codegen: &CodeGen) -> OpResult
                 to_register,
                 Transformation::Set(new_value),
                 line_number,
-                &codegen,
+                context,
             )?)
         },
         Operand::Literal(_) => {
@@ -136,7 +136,7 @@ pub fn assign(operands: &str, line_number: usize, codegen: &CodeGen) -> OpResult
                         to_register,
                         Transformation::Set(&operands[0]),
                         line_number,
-                        &codegen,
+                        context,
                     )?)
                 },
                 _ => Err(Error::new(
@@ -153,7 +153,7 @@ pub fn assign(operands: &str, line_number: usize, codegen: &CodeGen) -> OpResult
 }
 
 /// Adds a register's value to another register's value.
-pub fn add(operands: &str, line_number: usize, codegen: &CodeGen) -> OpResult {
+pub fn add(operands: &str, line_number: usize, context: &mut Context) -> OpResult {
     debug!("add with operands: {}", operands);
 
     let operands = parse_operands(operands)?;
@@ -189,12 +189,12 @@ pub fn add(operands: &str, line_number: usize, codegen: &CodeGen) -> OpResult {
         register,
         Transformation::Add(to_add),
         line_number,
-        &codegen,
+        context,
     )?)
 }
 
 /// Subtracts a register's value from another register's value.
-pub fn subtract(operands: &str, line_number: usize, codegen: &CodeGen) -> OpResult {
+pub fn subtract(operands: &str, line_number: usize, context: &mut Context) -> OpResult {
     debug!("subtract with operands: {}", operands);
 
     let operands = parse_operands(operands)?;
@@ -230,12 +230,12 @@ pub fn subtract(operands: &str, line_number: usize, codegen: &CodeGen) -> OpResu
         register,
         Transformation::Subtract(to_sub),
         line_number,
-        &codegen,
+        context,
     )?)
 }
 
 /// Reads a byte from stdin.
-pub fn read(operands: &str, line_number: usize, codegen: &CodeGen) -> OpResult {
+pub fn read(operands: &str, line_number: usize, context: &mut Context) -> OpResult {
     debug!("read with operands: {}", operands);
 
     let operands = parse_operands(operands)?;
@@ -257,13 +257,13 @@ pub fn read(operands: &str, line_number: usize, codegen: &CodeGen) -> OpResult {
         }
     };
 
-    codegen.gen_read(register);
+    context.gen_read(register);
 
     Ok(())
 }
 
 /// Prints a register's value.
-pub fn print(operands: &str, line_number: usize, codegen: &CodeGen) -> OpResult {
+pub fn print(operands: &str, line_number: usize, context: &mut Context) -> OpResult {
     debug!("print with operands: {}", operands);
 
     let operands = parse_operands(operands)?;
@@ -285,12 +285,12 @@ pub fn print(operands: &str, line_number: usize, codegen: &CodeGen) -> OpResult 
         }
     };
 
-    codegen.gen_print(register);
+    context.gen_print(register);
     Ok(())
 }
 
 /// Jumps to a label.
-pub fn jump(operands: &str, line_number: usize, codegen: &CodeGen) -> OpResult {
+pub fn jump(operands: &str, line_number: usize, context: &mut Context) -> OpResult {
     debug!("jump with operands: {}", operands);
 
     let operands = parse_operands(operands)?;
@@ -312,19 +312,19 @@ pub fn jump(operands: &str, line_number: usize, codegen: &CodeGen) -> OpResult {
         }
     };
 
-    if !codegen.has_label(label) {
+    if !context.has_label(label) {
         return Err(Error::new(
             &format!("jump to undefined label “{}”", label),
             line_number,
         ))
     }
 
-    codegen.gen_jump(label);
+    context.gen_jump(label);
     Ok(())
 }
 
 /// Jumps to a label if a register's value is 0.
-pub fn jump_if_zero(operands: &str, line_number: usize, codegen: &CodeGen) -> OpResult {
+pub fn jump_if_zero(operands: &str, line_number: usize, context: &mut Context) -> OpResult {
     debug!("jump if zero with operands: {}", operands);
 
     let operands = parse_operands(operands)?;
@@ -356,20 +356,20 @@ pub fn jump_if_zero(operands: &str, line_number: usize, codegen: &CodeGen) -> Op
         }
     };
 
-    if !codegen.has_label(label) {
+    if !context.has_label(label) {
         return Err(Error::new(
             &format!("jump to undefined label “{}”", label),
             line_number,
         ))
     }
 
-    codegen.gen_jump_if_zero(register, label);
+    context.gen_jump_if_zero(register, label);
 
     Ok(())
 }
 
 /// Jumps to a label if a register's value is negative.
-pub fn jump_if_neg(operands: &str, line_number: usize, codegen: &CodeGen) -> OpResult {
+pub fn jump_if_neg(operands: &str, line_number: usize, context: &mut Context) -> OpResult {
     debug!("jump if negative with operands: {}", operands);
 
     let operands = parse_operands(operands)?;
@@ -401,14 +401,14 @@ pub fn jump_if_neg(operands: &str, line_number: usize, codegen: &CodeGen) -> OpR
         }
     };
 
-    if !codegen.has_label(label) {
+    if !context.has_label(label) {
         return Err(Error::new(
             &format!("jump to undefined label “{}”", label),
             line_number,
         ))
     }
 
-    codegen.gen_jump_if_neg(register, label);
+    context.gen_jump_if_neg(register, label);
 
     Ok(())
 }
@@ -505,9 +505,9 @@ pub enum Transformation<'op> {
 }
 
 /// Modifies the register with the provided name using the provided `Transformation`.
-fn modify_register(name: &str, transformation: Transformation, line_number: usize, codegen: &CodeGen) -> OpResult {
-    if codegen.has_register(name) {
-        codegen.gen_modify_register(name, transformation);
+fn modify_register(name: &str, transformation: Transformation, line_number: usize, context: &mut Context) -> OpResult {
+    if context.has_register(name) {
+        context.gen_modify_register(name, transformation);
         Ok(())
     } else {
         Err(Error::new(

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Context, OpResult, RuntimeError, LITERALS, LITERAL_CONNECTORS, OPERAND_CONNECTORS,
+    Context, OpResult, Error, LITERALS, LITERAL_CONNECTORS, OPERAND_CONNECTORS,
     REGISTER_NAMES,
 };
 use rand::Rng;
@@ -88,7 +88,7 @@ pub fn assign(operands: &str, mut context: &mut Context) -> OpResult {
     let operands = parse_operands(operands)?;
     // should be either a register followed by a register or literal, or a literal followed by a register
     if operands.len() != 2 {
-        return Err(RuntimeError::new(
+        return Err(Error::new(
             "wrong number of operands for assignment",
             context,
         ));
@@ -99,7 +99,7 @@ pub fn assign(operands: &str, mut context: &mut Context) -> OpResult {
             let new_value = match &operands[1] {
                 Operand::Register(name) => get_register_value(name, context)?,
                 Operand::Literal(val) => *val,
-                _ => return Err(RuntimeError::new(
+                _ => return Err(Error::new(
                     "second operand for assignment must be a register or literal",
                     context,
                 ))
@@ -120,13 +120,13 @@ pub fn assign(operands: &str, mut context: &mut Context) -> OpResult {
                         &mut context,
                     )?)
                 },
-                _ => Err(RuntimeError::new(
+                _ => Err(Error::new(
                     "second operand for assignment must be a register if the first operand is a literal",
                     context,
                 ))
             }
         },
-        _ => Err(RuntimeError::new(
+        _ => Err(Error::new(
             "first operand for assignment must be a register or literal",
             context,
         ))
@@ -140,7 +140,7 @@ pub fn add(operands: &str, mut context: &mut Context) -> OpResult {
     let operands = parse_operands(operands)?;
     // should be a register followed by a register
     if operands.len() != 2 {
-        return Err(RuntimeError::new(
+        return Err(Error::new(
             "wrong number of operands for add",
             context,
         ));
@@ -149,7 +149,7 @@ pub fn add(operands: &str, mut context: &mut Context) -> OpResult {
     let register = match &operands[0] {
         Operand::Register(name) => name,
         _ => {
-            return Err(RuntimeError::new(
+            return Err(Error::new(
                 "first operand for add must be a register",
                 context,
             ))
@@ -159,7 +159,7 @@ pub fn add(operands: &str, mut context: &mut Context) -> OpResult {
     let to_add = match &operands[1] {
         Operand::Register(name) => get_register_value(name, context)?,
         _ => {
-            return Err(RuntimeError::new(
+            return Err(Error::new(
                 "second operand for add must be a register",
                 context,
             ))
@@ -180,7 +180,7 @@ pub fn subtract(operands: &str, mut context: &mut Context) -> OpResult {
     let operands = parse_operands(operands)?;
     // should be a register followed by a register
     if operands.len() != 2 {
-        return Err(RuntimeError::new(
+        return Err(Error::new(
             "wrong number of operands for subtract",
             context,
         ));
@@ -189,7 +189,7 @@ pub fn subtract(operands: &str, mut context: &mut Context) -> OpResult {
     let register = match &operands[0] {
         Operand::Register(name) => name,
         _ => {
-            return Err(RuntimeError::new(
+            return Err(Error::new(
                 "first operand for subtract must be a register",
                 context,
             ))
@@ -199,7 +199,7 @@ pub fn subtract(operands: &str, mut context: &mut Context) -> OpResult {
     let to_sub = match &operands[1] {
         Operand::Register(name) => get_register_value(name, context)?,
         _ => {
-            return Err(RuntimeError::new(
+            return Err(Error::new(
                 "second operand for subtract must be a register",
                 context,
             ))
@@ -221,7 +221,7 @@ pub fn read(operands: &str, mut context: &mut Context) -> OpResult {
         Some(b) => match b {
             Ok(b) => b as i32,
             Err(e) => {
-                return Err(RuntimeError::new(
+                return Err(Error::new(
                     &format!("error reading from stdin: {}", e),
                     context,
                 ))
@@ -244,7 +244,7 @@ pub fn print(operands: &str, context: &mut Context) -> OpResult {
     let operands = parse_operands(operands)?;
     // should be a register
     if operands.len() != 1 {
-        return Err(RuntimeError::new(
+        return Err(Error::new(
             "wrong number of operands for print",
             context,
         ));
@@ -253,7 +253,7 @@ pub fn print(operands: &str, context: &mut Context) -> OpResult {
     let register = match &operands[0] {
         Operand::Register(name) => name,
         _ => {
-            return Err(RuntimeError::new(
+            return Err(Error::new(
                 "operand for print must be a register",
                 context,
             ))
@@ -262,7 +262,7 @@ pub fn print(operands: &str, context: &mut Context) -> OpResult {
 
     let to_print = get_register_value(register, context)?;
     if to_print < 0 {
-        return Err(RuntimeError::new(
+        return Err(Error::new(
             &format!(
                 "{} does not correspond to a valid UTF-8 character",
                 to_print
@@ -277,7 +277,7 @@ pub fn print(operands: &str, context: &mut Context) -> OpResult {
             std::io::stdout().flush().unwrap();
         }
         _ => {
-            return Err(RuntimeError::new(
+            return Err(Error::new(
                 &format!(
                     "{} does not correspond to a valid UTF-8 character",
                     to_print
@@ -304,7 +304,7 @@ pub fn jump_if_zero(operands: &str, context: &mut Context) -> OpResult {
     let operands = parse_operands(operands)?;
     // should be a register and a label
     if operands.len() != 2 {
-        return Err(RuntimeError::new(
+        return Err(Error::new(
             "wrong number of operands for jump if zero",
             context,
         ));
@@ -313,7 +313,7 @@ pub fn jump_if_zero(operands: &str, context: &mut Context) -> OpResult {
     let register = match &operands[0] {
         Operand::Register(name) => name,
         _ => {
-            return Err(RuntimeError::new(
+            return Err(Error::new(
                 "first operand for jump if zero must be a register",
                 context,
             ))
@@ -323,7 +323,7 @@ pub fn jump_if_zero(operands: &str, context: &mut Context) -> OpResult {
     let label = match &operands[1] {
         Operand::Label(name) => name,
         _ => {
-            return Err(RuntimeError::new(
+            return Err(Error::new(
                 "second operand for jump if zero must be a label",
                 context,
             ))
@@ -344,7 +344,7 @@ pub fn jump_if_neg(operands: &str, context: &mut Context) -> OpResult {
     let operands = parse_operands(operands)?;
     // should be a register and a label
     if operands.len() != 2 {
-        return Err(RuntimeError::new(
+        return Err(Error::new(
             "wrong number of operands for jump if negative",
             context,
         ));
@@ -353,7 +353,7 @@ pub fn jump_if_neg(operands: &str, context: &mut Context) -> OpResult {
     let register = match &operands[0] {
         Operand::Register(name) => name,
         _ => {
-            return Err(RuntimeError::new(
+            return Err(Error::new(
                 "first operand for jump if negative must be a register",
                 context,
             ))
@@ -363,7 +363,7 @@ pub fn jump_if_neg(operands: &str, context: &mut Context) -> OpResult {
     let label = match &operands[1] {
         Operand::Label(name) => name,
         _ => {
-            return Err(RuntimeError::new(
+            return Err(Error::new(
                 "second operand for jump if negative must be a label",
                 context,
             ))
@@ -389,7 +389,7 @@ enum Operand {
 }
 
 /// Parses a string of operands to a list of `Operand`s.
-fn parse_operands(operands: &str) -> Result<Vec<Operand>, RuntimeError> {
+fn parse_operands(operands: &str) -> Result<Vec<Operand>, Error> {
     let mut remaining_operands = operands.to_string();
     let mut parsed_operands = Vec::new();
     'outer: while !remaining_operands.is_empty() {
@@ -460,10 +460,10 @@ fn parse_literal(operands: &mut String) -> i32 {
 }
 
 /// Gets the value stored in the register with the provided name.
-fn get_register_value(name: &str, context: &Context) -> Result<i32, RuntimeError> {
+fn get_register_value(name: &str, context: &Context) -> Result<i32, Error> {
     match context.registers.get(name) {
         Some(x) => Ok(*x),
-        _ => Err(RuntimeError::new(
+        _ => Err(Error::new(
             &format!("invalid register name: {}", name),
             context,
         )),
@@ -483,7 +483,7 @@ fn modify_register(name: &str, transformation: Transformation, context: &mut Con
     let mut register = match context.registers.entry(name.to_string()) {
         Occupied(e) => e,
         _ => {
-            return Err(RuntimeError::new(
+            return Err(Error::new(
                 &format!("invalid register name: {}", name),
                 context,
             ))
@@ -505,7 +505,7 @@ fn jump_to_label(name: &str, mut context: &mut Context) -> OpResult {
     match context.labels.get(name) {
         Some(x) => context.current_line_number = *x,
         _ => {
-            return Err(RuntimeError::new(
+            return Err(Error::new(
                 &format!("unknown label: {}", name),
                 context,
             ))

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -2,7 +2,6 @@ use crate::{
     OpResult, Error, LITERALS, LITERAL_CONNECTORS, OPERAND_CONNECTORS,
     REGISTER_NAMES, codegen::CodeGen,
 };
-use rand::Rng;
 use regex::Regex;
 
 /// Adds a label.
@@ -76,15 +75,27 @@ pub fn halve(operands: &str, line_number: usize, codegen: &CodeGen) -> OpResult 
 pub fn randomize(operands: &str, line_number: usize, codegen: &CodeGen) -> OpResult {
     debug!("randomize with operands: {}", operands);
 
-    let random_number = rand::thread_rng().gen_range(0, 10);
+    let operands = parse_operands(operands)?;
+    // should be a register
+    if operands.len() != 1 {
+        return Err(Error::new(
+            "wrong number of operands for randomize",
+            line_number,
+        ));
+    }
 
-    // TODO: implement in library
-    Ok(modify_register(
-        operands,
-        Transformation::Set(&Operand::Literal(random_number)),
-        line_number,
-        &codegen,
-    )?)
+    let register = match &operands[0] {
+        Operand::Register(name) => name,
+        _ => {
+            return Err(Error::new(
+                "operand for randomize must be a register",
+                line_number,
+            ))
+        }
+    };
+
+    codegen.gen_randomize(register);
+    Ok(())
 }
 
 /// Sets a register's value to the value in another register or a literal value.


### PR DESCRIPTION
I find the lack of performance disturbing, so I've implemented a LLVM JIT for the language with [Inkwell](https://github.com/TheDan64/inkwell).
This obviously has huge performance gains, making fizzbuzz over 150 times faster, therefore suitable for production use:

    # classic interpreter version
    ~/D/P/strategic-communication master ❯ \time -p  target/release/strategic-communication examples/fizzbuzz.business
    1
    2
    Fizz
    4
    Buzz
    [ removed or brevity]
    98
    Fizz
    real         3.18
    user         3.16
    sys          0.01
    
    # LLVM-jit version
    ~/D/P/strategic-communication llvm ❯ \time -p  target/release/strategic-communication -O0 examples/fizzbuzz.business
    1
    2
    Fizz
    4
    Buzz
    [ removed for brevity ]
    98
    Fizz
    real         0.02
    user         0.02
    sys          0.00

It is implemented as a compile-time feature `llvm`.
To build, you must have LLVM installed. I [downloaded](https://releases.llvm.org/download.html) the 10.0.0 binary release for my platform and pointed  `LLVM_SYS_100_PREFIX` to where I installed it:

    export LLVM_SYS_100_PREFIX=/usr/local/llvm/clang+llvm-10.0.0-x86_64-apple-darwin
    cargo build --features llvm

It also adds the following options to the command line:

    -i, --print-ir    Print the LLVM IR to the console
        --view-cfg    View the control flow graph
    -O, --optimization-level <optimization-level>    [default: 2] [possible values: 0, 1, 2, 3]

Some examples:
* [Unoptimized hello world](https://gist.github.com/zydeco/ec9f73eb5371f0c1d258b95a56deddea#file-unoptimized-hello-world-out)
* [Optimized hello world](https://gist.github.com/zydeco/ec9f73eb5371f0c1d258b95a56deddea#file-optimized-hello-world-out)
* [Optimized fizzbuzz](https://gist.github.com/zydeco/ec9f73eb5371f0c1d258b95a56deddea#file-optimized-fizzbuzz-out)
* [Optimized fizzbuzz control flow graph](https://dreampuf.github.io/GraphvizOnline/#digraph%20%22CFG%20for%20'main'%20function%22%20%7B%0A%09label%3D%22CFG%20for%20'main'%20function%22%3B%0A%0A%09Node0x7fb03741de10%20%5Bshape%3Drecord%2Clabel%3D%22%7Bentry%7D%22%5D%3B%0A%09Node0x7fb03741de10%20-%3E%20Node0x7fb037420af0%3B%0A%09Node0x7fb0374207c0%20%5Bshape%3Drecord%2Clabel%3D%22%7Bmake%20it%20pop%7D%22%5D%3B%0A%09Node0x7fb0374207c0%20-%3E%20Node0x7fb037420910%3B%0A%09Node0x7fb0374208a0%20%5Bshape%3Drecord%2Clabel%3D%22%7Bengage%20in%20deep%20dive%7D%22%5D%3B%0A%09Node0x7fb0374208a0%20-%3E%20Node0x7fb037420a70%3B%0A%09Node0x7fb0374209d0%20%5Bshape%3Drecord%2Clabel%3D%22%7Bstrive%20for%20success%7C%7B%3Cs0%3ET%7C%3Cs1%3EF%7D%7D%22%5D%3B%0A%09Node0x7fb0374209d0%3As0%20-%3E%20Node0x7fb037420a70%3B%0A%09Node0x7fb0374209d0%3As1%20-%3E%20Node0x7fb037705060%3B%0A%09Node0x7fb037705060%20%5Bshape%3Drecord%2Clabel%3D%22%7Bstrive%20for%20success'%7C%7B%3Cs0%3ET%7C%3Cs1%3EF%7D%7D%22%5D%3B%0A%09Node0x7fb037705060%3As0%20-%3E%20Node0x7fb037420830%3B%0A%09Node0x7fb037705060%3As1%20-%3E%20Node0x7fb037704fe0%3B%0A%09Node0x7fb037704fe0%20%5Bshape%3Drecord%2Clabel%3D%22%7Bstrive%20for%20success''%7D%22%5D%3B%0A%09Node0x7fb037704fe0%20-%3E%20Node0x7fb037420830%3B%0A%09Node0x7fb037420830%20%5Bshape%3Drecord%2Clabel%3D%22%7Bminimize%20impact%7D%22%5D%3B%0A%09Node0x7fb037420830%20-%3E%20Node0x7fb037420a70%3B%0A%09Node0x7fb037420ba0%20%5Bshape%3Drecord%2Clabel%3D%22%7Breduce%20cost%20basis%7C%7B%3Cs0%3ET%7C%3Cs1%3EF%7D%7D%22%5D%3B%0A%09Node0x7fb037420ba0%3As0%20-%3E%20Node0x7fb0374207c0%3B%0A%09Node0x7fb037420ba0%3As1%20-%3E%20Node0x7fb037705d50%3B%0A%09Node0x7fb037705d50%20%5Bshape%3Drecord%2Clabel%3D%22%7Breduce%20cost%20basis'%7C%7B%3Cs0%3ET%7C%3Cs1%3EF%7D%7D%22%5D%3B%0A%09Node0x7fb037705d50%3As0%20-%3E%20Node0x7fb037420910%3B%0A%09Node0x7fb037705d50%3As1%20-%3E%20Node0x7fb037420ba0%3B%0A%09Node0x7fb037420910%20%5Bshape%3Drecord%2Clabel%3D%22%7Bscalability%7D%22%5D%3B%0A%09Node0x7fb037420910%20-%3E%20Node0x7fb037420c10%3B%0A%09Node0x7fb037420c10%20%5Bshape%3Drecord%2Clabel%3D%22%7Breimagined%20scalability%7C%7B%3Cs0%3ET%7C%3Cs1%3EF%7D%7D%22%5D%3B%0A%09Node0x7fb037420c10%3As0%20-%3E%20Node0x7fb0374208a0%3B%0A%09Node0x7fb037420c10%3As1%20-%3E%20Node0x7fb0377063b0%3B%0A%09Node0x7fb0377063b0%20%5Bshape%3Drecord%2Clabel%3D%22%7Breimagined%20scalability'%7C%7B%3Cs0%3ET%7C%3Cs1%3EF%7D%7D%22%5D%3B%0A%09Node0x7fb0377063b0%3As0%20-%3E%20Node0x7fb0374209d0%3B%0A%09Node0x7fb0377063b0%3As1%20-%3E%20Node0x7fb037420c10%3B%0A%09Node0x7fb037420c80%20%5Bshape%3Drecord%2Clabel%3D%22%7Bseamlessly%20integrate%7D%22%5D%3B%0A%09Node0x7fb037420c80%20-%3E%20Node0x7fb037420f10%3B%0A%09Node0x7fb037420a70%20%5Bshape%3Drecord%2Clabel%3D%22%7Bmindshare%7D%22%5D%3B%0A%09Node0x7fb037420a70%20-%3E%20Node0x7fb037420af0%3B%0A%09Node0x7fb037420af0%20%5Bshape%3Drecord%2Clabel%3D%22%7Bholistic%20approach%7C%7B%3Cs0%3ET%7C%3Cs1%3EF%7D%7D%22%5D%3B%0A%09Node0x7fb037420af0%3As0%20-%3E%20Node0x7fb037420c80%3B%0A%09Node0x7fb037420af0%3As1%20-%3E%20Node0x7fb037420f10%3B%0A%09Node0x7fb037420f10%20%5Bshape%3Drecord%2Clabel%3D%22%7Bharden%20cloud%20infrastructure%7C%7B%3Cs0%3ET%7C%3Cs1%3EF%7D%7D%22%5D%3B%0A%09Node0x7fb037420f10%3As0%20-%3E%20Node0x7fb037420f90%3B%0A%09Node0x7fb037420f10%3As1%20-%3E%20Node0x7fb037604d30%3B%0A%09Node0x7fb037604d30%20%5Bshape%3Drecord%2Clabel%3D%22%7Bharden%20cloud%20infrastructure'%7D%22%5D%3B%0A%09Node0x7fb037604d30%20-%3E%20Node0x7fb037420ba0%3B%0A%09Node0x7fb037420f90%20%5Bshape%3Drecord%2Clabel%3D%22%7Bcall%20it%20a%20day%7D%22%5D%3B%0A%7D%0A)
